### PR TITLE
action: Cache RT-Thread repository

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -41,22 +41,43 @@ jobs:
           key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ env.CACHE_REVISION }}
 
       -
-        name: Checkout-RTT
+        name: Restore RTT cache
+        id: rtt-cache
+        uses: actions/cache@v3
+        env:
+          CACHE_NAME: 'rtt-cache'
+        with:
+          # rtt-dependencies/
+          #path: ${{ github.workspace }}/rtt-dependencies/mountPkg/
+          path: ${{ github.workspace }}/rtt-repo/
+          key: ${{ runner.os }}-repo-${{ env.CACHE_NAME }}-${{ env.CACHE_REVISION }}
+
+      -
+        name: Checkout RTT
         uses: actions/checkout@v3
+        if: steps.rtt-cache.outputs.cache-hit != 'true'
         with:
           repository: rt-thread/rt-thread
           path: rtt-repo
+
+      - name: Save RTT cache
+        id: cache-rtt-save
+        env:
+          CACHE_NAME: 'rtt-cache'
+        if: steps.rtt-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ github.workspace }}/rtt-repo/
+          key: ${{ runner.os }}-repo-${{ env.CACHE_NAME }}-${{ env.CACHE_REVISION }}
 
       - name: Run test suite with Docker
         uses: addnab/docker-run-action@v3
         with:
             image: tuduweb/rttciimage:latest
-            options: -v ${{ github.workspace }}/rtt-repo:/opt/rt-thread/ -v /opt/gcc-arm-none-eabi-10-2020-q4-major/:/opt/gcc-arm-none-eabi-10-2020-q4-major/
+            options: -v ${{ github.workspace }}:/opt/workspace/ -v /opt/gcc-arm-none-eabi-10-2020-q4-major/:/opt/gcc-arm-none-eabi-10-2020-q4-major/
             run: |
-                export RTT_CC=gcc RTT_ROOT=/opt/rt-thread RTT_EXEC_PATH=/opt/gcc-arm-none-eabi-10-2020-q4-major/bin RTT_BSP=qemu-vexpress-a9 RTT_TOOL_CHAIN=sourcery-arm
-                cd /opt/rt-thread/
-                ls
-                ls -l
-                #bash /opt/rt-thread/CI/ubuntu/run-test.sh
-                python -c "import tools.menuconfig; tools.menuconfig.touch_env()"
-                scons -C bsp/$RTT_BSP
+                export RTT_CC=gcc RTT_ROOT=/opt/workspace/rtt-repo RTT_EXEC_PATH=/opt/gcc-arm-none-eabi-10-2020-q4-major/bin RTT_BSP=qemu-vexpress-a9 RTT_TOOL_CHAIN=sourcery-arm
+                cd /opt/workspace/
+                bash ./CI/ubuntu/run-test.sh # not in rt-thread
+                #python -c "import tools.menuconfig; tools.menuconfig.touch_env()"
+                #scons -C bsp/$RTT_BSP


### PR DESCRIPTION
<!--  from obs -->

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here:  -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Cache RT-Thread repository via Action CI cache.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

To accelerate the Action CI.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Repush.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
